### PR TITLE
Makefile path change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 .SUFFIXES:
 #---------------------------------------------------------------------------------
 
-export DEVKITPRO=/users/bert/devkitpro
-export DEVKITARM=/users/bert/devkitpro/devkitARM
+export DEVKITPRO=C:/devkitPro
+export DEVKITARM=C:/devkitPro/devkitARM
 
 ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")


### PR DESCRIPTION
I changed the export path's (rule 5,6)
Since everyone is having devkitpro on his C:/ its not necessary to locate to C:/users/username/DevkitPRO

Also rule 5,6 was locating to C:/users/Bert/
Since not everyone is called "Bert" this rules were useless.

No problem :D